### PR TITLE
[FEAT] 산 검색 스크린 구현

### DIFF
--- a/src/app/(tabs)/home/course.tsx
+++ b/src/app/(tabs)/home/course.tsx
@@ -1,7 +1,8 @@
-import { View } from "react-native";
+import WebViewWithInjected from "@components/common/entities/WebViewWithInjected";
+import PATH_ROUTE from "@constants/pathRoute";
 
 const CourseScreen = () => {
-  return <View></View>;
+  return <WebViewWithInjected source={{ uri: PATH_ROUTE.WEBVIEW.COURSE }} />;
 };
 
 export default CourseScreen;

--- a/src/app/(tabs)/home/course.tsx
+++ b/src/app/(tabs)/home/course.tsx
@@ -1,8 +1,0 @@
-import WebViewWithInjected from "@components/common/entities/WebViewWithInjected";
-import PATH_ROUTE from "@constants/pathRoute";
-
-const CourseScreen = () => {
-  return <WebViewWithInjected source={{ uri: PATH_ROUTE.WEBVIEW.COURSE }} />;
-};
-
-export default CourseScreen;

--- a/src/app/(tabs)/home/course/[mountainName].tsx
+++ b/src/app/(tabs)/home/course/[mountainName].tsx
@@ -1,0 +1,15 @@
+import Text from "@components/common/shared/ui/Text";
+import { useLocalSearchParams } from "expo-router";
+import { View } from "react-native";
+
+const MountainCourseScreen = () => {
+  const { mountainName } = useLocalSearchParams();
+
+  return (
+    <View>
+      <Text>{mountainName}</Text>
+    </View>
+  );
+};
+
+export default MountainCourseScreen;

--- a/src/app/(tabs)/home/course/index.tsx
+++ b/src/app/(tabs)/home/course/index.tsx
@@ -1,0 +1,7 @@
+import MountainSearchWebview from "@components/feature/screens/course/MountainSearchWebview";
+
+const CourseScreen = () => {
+  return <MountainSearchWebview />;
+};
+
+export default CourseScreen;

--- a/src/components/feature/screens/course/MountainSearchWebview/index.tsx
+++ b/src/components/feature/screens/course/MountainSearchWebview/index.tsx
@@ -1,0 +1,19 @@
+import WebViewWithInjected from "@components/common/entities/WebViewWithInjected";
+import PATH_ROUTE from "@constants/pathRoute";
+import { router } from "expo-router";
+
+const MountainSearchWebview = () => {
+  return (
+    <WebViewWithInjected
+      source={{ uri: PATH_ROUTE.WEBVIEW.COURSE }}
+      onMessage={({ method, name, body }) => {
+        if (name === "request-navigate" && method === "POST") {
+          const { mountainName } = body as { mountainName: string };
+          router.push(`/(tabs)/home/course/${mountainName}`);
+        }
+      }}
+    />
+  );
+};
+
+export default MountainSearchWebview;

--- a/src/components/feature/widget/LoginWebView/index.tsx
+++ b/src/components/feature/widget/LoginWebView/index.tsx
@@ -4,6 +4,7 @@ import PATH_ROUTE from "@constants/pathRoute";
 import { setValueToSecureStore } from "@utils/secureStore";
 import { useCallback, useRef } from "react";
 import WebView from "react-native-webview";
+import { postMessage } from "@utils/bridge";
 
 interface KakaoTokens {
   accessToken: string;

--- a/src/constants/pathRoute/index.ts
+++ b/src/constants/pathRoute/index.ts
@@ -4,6 +4,7 @@ const WEBVIEW = {
   BASE_URL: webviewBaseUri,
   LOGIN: `${webviewBaseUri}/login`,
   EMAIL_AUTH: `${webviewBaseUri}/email-auth`,
+  COURSE: `${webviewBaseUri}/course`,
 } as const;
 
 const PATH_ROUTE = {

--- a/src/utils/bridge/index.ts
+++ b/src/utils/bridge/index.ts
@@ -1,6 +1,9 @@
 import { RefObject } from "react";
 import WebView from "react-native-webview";
 
-export const postMessage = (ref: RefObject<WebView<{}>>, message: string) => {
+export const postMessage = (
+  ref: RefObject<WebView<{}> | null>,
+  message: string,
+) => {
   ref.current?.postMessage(message);
 };


### PR DESCRIPTION
- #15 
## 주요 변경 사항
산 검색 스크린을 구현하였습니다. 
해당 페이지는 UI 변경에 용이하도록 웹뷰로 구현하게 되었습니다. 

웹상에서 산을 선택하게되면 해당 산의 코스들을 보여주는 스크린으로 route하는 브리지 로직을 작성하였습니다. 

<div align="center">
<img width="50%" src="https://github.com/user-attachments/assets/41ff07b5-4f80-4ddb-bc86-6e00b3dd8096"/>
</div>