### PR TITLE
[FEAT] 안전 매뉴얼 스크린 구현

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -1,4 +1,4 @@
-import { COLORS } from "@/src/styles/colorPalette";
+import QueryProvider from "@service/query/provider";
 import {
   HeroSVG,
   HomeBlockSVG,
@@ -7,8 +7,8 @@ import {
   MapSVG,
   MountainSVG,
   StoreSVG,
-} from "@components/common/shared/ui/Icons";
-import QueryProvider from "@/src/service/query/provider";
+} from "@shared/ui/Icons";
+import { COLORS } from "@styles/colorPalette";
 import { Tabs } from "expo-router";
 
 export default function TabLayout() {

--- a/src/app/(tabs)/home/safeManual/[manual].tsx
+++ b/src/app/(tabs)/home/safeManual/[manual].tsx
@@ -1,0 +1,18 @@
+import styled from "@emotion/native";
+import SafeManualDetailWebview from "@screens/SafeManual/SafeManualDetailWebview";
+import { COLORS } from "@styles/colorPalette";
+
+const SafeManualDetailScreen = () => {
+  return (
+    <Container>
+      <SafeManualDetailWebview />
+    </Container>
+  );
+};
+
+const Container = styled.SafeAreaView`
+  flex: 1;
+  background-color: ${COLORS.mainWhite};
+`;
+
+export default SafeManualDetailScreen;

--- a/src/app/(tabs)/home/safeManual/_layout.tsx
+++ b/src/app/(tabs)/home/safeManual/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from "expo-router";
+
+const _layout = () => {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+      }}
+    />
+  );
+};
+
+export default _layout;

--- a/src/app/(tabs)/home/safeManual/index.tsx
+++ b/src/app/(tabs)/home/safeManual/index.tsx
@@ -1,0 +1,18 @@
+import styled from "@emotion/native";
+import SafeManualWebview from "@screens/SafeManual/SafeManualWebview";
+import { COLORS } from "@styles/colorPalette";
+
+const SafeManualScreen = () => {
+  return (
+    <Container>
+      <SafeManualWebview />
+    </Container>
+  );
+};
+
+const Container = styled.SafeAreaView`
+  flex: 1;
+  background-color: ${COLORS.mainWhite};
+`;
+
+export default SafeManualScreen;

--- a/src/app/(tabs)/mypage/_layout.tsx
+++ b/src/app/(tabs)/mypage/_layout.tsx
@@ -1,0 +1,13 @@
+import Stack from "expo-router/stack";
+
+const _MypageLayout = () => {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+      }}
+    />
+  );
+};
+
+export default _MypageLayout;

--- a/src/app/(tabs)/mypage/index.tsx
+++ b/src/app/(tabs)/mypage/index.tsx
@@ -1,19 +1,11 @@
-import WebViewWithInjected from "@components/common/entities/WebViewWithInjected";
-import { View } from "react-native";
+import PATH_ROUTE from "@constants/pathRoute";
+import WebViewWithInjected from "@entities/WebViewWithInjected";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 const MyPageScreen = () => {
   return (
     <SafeAreaView style={{ flex: 1 }}>
-      <View
-        style={{
-          flex: 1,
-        }}
-      >
-        <WebViewWithInjected
-          source={{ uri: "http://localhost:3000/my-page" }}
-        />
-      </View>
+      <WebViewWithInjected source={{ uri: PATH_ROUTE.WEBVIEW.MYPAGE }} />
     </SafeAreaView>
   );
 };

--- a/src/components/common/entities/WebViewWithInjected/index.tsx
+++ b/src/components/common/entities/WebViewWithInjected/index.tsx
@@ -10,7 +10,9 @@ import {
   DISABLED_TEXT_SELECT,
   SET_VIEWPORT_RATE,
 } from "@constants/webview";
+import { getPathToRoute } from "@utils/bridge";
 import { logMessageWithTime } from "@utils/log";
+import { router } from "expo-router";
 import {
   forwardRef,
   useCallback,
@@ -84,6 +86,29 @@ const WebViewWithInjected = forwardRef<WebView, WebViewWithInjectedProps>(
         if (reqMessage.name === ("log-message" as string)) {
           console.log(reqMessage.body);
           return;
+        }
+
+        // 라우팅 메시지 처리
+        if (
+          reqMessage.name === ("route-to" as string) &&
+          reqMessage.method === "POST"
+        ) {
+          const { path, routeType, params } = reqMessage.body as {
+            path: string;
+            routeType?: "replace" | "push";
+            params?: Record<string, any>[];
+          };
+
+          routeType === "replace"
+            ? router.replace(getPathToRoute({ path, params }))
+            : router.push(getPathToRoute({ path, params }));
+
+          // 동적 에러처리 필요
+
+          return {
+            name: "route-to",
+            status: "success",
+          };
         }
 
         logMessageWithTime(`WebView received: \n${JSON.stringify(reqMessage)}`);

--- a/src/components/feature/screens/Home/HomeNavGridSection/index.tsx
+++ b/src/components/feature/screens/Home/HomeNavGridSection/index.tsx
@@ -17,7 +17,7 @@ const HomeNavGridSection = () => {
     router.navigate("/report");
   }, []);
   const goManual = useCallback(() => {
-    router.push("/(tabs)/home/course");
+    router.push("/(tabs)/home/safeManual");
   }, []);
 
   return (

--- a/src/components/feature/screens/SafeManual/SafeManualDetailWebview/index.tsx
+++ b/src/components/feature/screens/SafeManual/SafeManualDetailWebview/index.tsx
@@ -1,0 +1,24 @@
+import PATH_ROUTE from "@constants/pathRoute";
+import WebViewWithInjected from "@entities/WebViewWithInjected";
+import { router, useLocalSearchParams } from "expo-router";
+
+const SafeManualDetailWebview = () => {
+  const { manual } = useLocalSearchParams();
+
+  return (
+    <WebViewWithInjected
+      source={{
+        uri: PATH_ROUTE.WEBVIEW.SAFE_MANUAL_DETAIL({
+          manual: manual as string,
+        }),
+      }}
+      onMessage={({ method, name }) => {
+        if (name === "route-back" && method === "POST") {
+          router.back();
+        }
+      }}
+    />
+  );
+};
+
+export default SafeManualDetailWebview;

--- a/src/components/feature/screens/SafeManual/SafeManualDetailWebview/index.tsx
+++ b/src/components/feature/screens/SafeManual/SafeManualDetailWebview/index.tsx
@@ -5,11 +5,16 @@ import { router, useLocalSearchParams } from "expo-router";
 const SafeManualDetailWebview = () => {
   const { manual } = useLocalSearchParams();
 
+  if (!manual || typeof manual !== "string") {
+    console.error("Invalid manual parameter");
+    return null;
+  }
+
   return (
     <WebViewWithInjected
       source={{
         uri: PATH_ROUTE.WEBVIEW.SAFE_MANUAL_DETAIL({
-          manual: manual as string,
+          manual: manual,
         }),
       }}
       onMessage={({ method, name }) => {

--- a/src/components/feature/screens/SafeManual/SafeManualWebview/index.tsx
+++ b/src/components/feature/screens/SafeManual/SafeManualWebview/index.tsx
@@ -1,0 +1,20 @@
+import PATH_ROUTE from "@constants/pathRoute";
+import WebViewWithInjected from "@entities/WebViewWithInjected";
+import { router } from "expo-router";
+
+const SafeManualWebview = () => {
+  return (
+    <WebViewWithInjected
+      source={{
+        uri: PATH_ROUTE.WEBVIEW.SAFE_MANUAL,
+      }}
+      onMessage={({ method, name, body }) => {
+        if (name === "route-back" && method === "POST") {
+          router.back();
+        }
+      }}
+    />
+  );
+};
+
+export default SafeManualWebview;

--- a/src/components/feature/screens/course/MountainCourseWebview/index.tsx
+++ b/src/components/feature/screens/course/MountainCourseWebview/index.tsx
@@ -1,5 +1,5 @@
-import WebViewWithInjected from "@components/common/entities/WebViewWithInjected";
 import PATH_ROUTE from "@constants/pathRoute";
+import WebViewWithInjected from "@entities/WebViewWithInjected";
 import { router, useLocalSearchParams } from "expo-router";
 
 const MountainCourseWebview = () => {

--- a/src/components/feature/screens/course/MountainSearchWebview/index.tsx
+++ b/src/components/feature/screens/course/MountainSearchWebview/index.tsx
@@ -1,4 +1,4 @@
-import WebViewWithInjected from "@components/common/entities/WebViewWithInjected";
+import WebViewWithInjected from "@entities/WebViewWithInjected";
 import PATH_ROUTE from "@constants/pathRoute";
 import { router } from "expo-router";
 

--- a/src/components/feature/screens/map/CourseDetailWebview/index.tsx
+++ b/src/components/feature/screens/map/CourseDetailWebview/index.tsx
@@ -19,13 +19,6 @@ const CourseDetailWebview = () => {
             status: "success",
           };
         }
-        if (name === "route-course-detail" && method === "POST") {
-          router.replace("/(tabs)/map/course");
-          return {
-            name: "route-course-detail",
-            status: "success",
-          };
-        }
         if (name === "get-current-position" && method === "GET") {
           return {
             name: "get-current-position",

--- a/src/constants/bridge/index.ts
+++ b/src/constants/bridge/index.ts
@@ -1,0 +1,12 @@
+import { Href } from "expo-router";
+
+type PathToRoute = { [key: string]: Href };
+
+const PATH_TO_ROUTE: PathToRoute = {
+  "course-detail": "/(tabs)/map/course",
+  "start-travel": "/(tabs)/map/travel",
+  "mountain-course": "/(tabs)/map/course",
+  "manual-detail": "/(tabs)/home/safeManual/[manual]",
+} as const;
+
+export default PATH_TO_ROUTE;

--- a/src/constants/pathRoute/index.ts
+++ b/src/constants/pathRoute/index.ts
@@ -16,6 +16,7 @@ const WEBVIEW = {
   MAP: `${webviewBaseUri}/map`,
   MAP_COURSE_SEARCH: `${webviewBaseUri}/map/course-search`,
   MAP_COURSE_DETAIL: `${webviewBaseUri}/map/course-detail`,
+  MYPAGE: `${webviewBaseUri}/my-page`,
 } as const;
 
 const PATH_ROUTE = {

--- a/src/constants/pathRoute/index.ts
+++ b/src/constants/pathRoute/index.ts
@@ -17,6 +17,9 @@ const WEBVIEW = {
   MAP_COURSE_SEARCH: `${webviewBaseUri}/map/course-search`,
   MAP_COURSE_DETAIL: `${webviewBaseUri}/map/course-detail`,
   MYPAGE: `${webviewBaseUri}/my-page`,
+  SAFE_MANUAL: `${webviewBaseUri}/safe-manual`,
+  SAFE_MANUAL_DETAIL: ({ manual }: { manual: string }) =>
+    `${webviewBaseUri}/safe-manual/detail?manual=${manual}`,
 } as const;
 
 const PATH_ROUTE = {

--- a/src/utils/bridge/index.test.ts
+++ b/src/utils/bridge/index.test.ts
@@ -1,0 +1,46 @@
+import { getPathToRoute } from './index';
+
+describe('getPathToRoute', () => {
+  it('파라미터 없이 올바른 경로를 반환해야 함', () => {
+    const result = getPathToRoute({ path: 'course-detail' });
+    expect(result).toBe('/(tabs)/map/course');
+  });
+
+  it('파라미터와 함께 올바른 경로를 반환해야 함', () => {
+    const result = getPathToRoute({ 
+      path: 'manual-detail', 
+      params: [{ manual: 'safety-guide' }] 
+    });
+    expect(result).toBe('/(tabs)/home/safeManual/safety-guide');
+  });
+
+  it('다중 파라미터를 처리해야 함', () => {
+    const result = getPathToRoute({ 
+      path: 'manual-detail', 
+      params: [{ manual: 'guide-1' }, { other: 'value' }] 
+    });
+    expect(result).toBe('/(tabs)/home/safeManual/guide-1');
+  });
+
+  it('잘못된 경로에 대해 에러를 발생시켜야 함', () => {
+    expect(() => {
+      getPathToRoute({ path: 'invalid-path' as any });
+    }).toThrow('Path not found for key: invalid-path');
+  });
+
+  it('빈 파라미터 배열을 처리해야 함', () => {
+    const result = getPathToRoute({ 
+      path: 'course-detail', 
+      params: [] 
+    });
+    expect(result).toBe('/(tabs)/map/course');
+  });
+
+  it('숫자 파라미터를 문자열로 변환해야 함', () => {
+    const result = getPathToRoute({ 
+      path: 'manual-detail', 
+      params: [{ manual: 123 }] 
+    });
+    expect(result).toBe('/(tabs)/home/safeManual/123');
+  });
+});

--- a/src/utils/bridge/index.ts
+++ b/src/utils/bridge/index.ts
@@ -1,3 +1,5 @@
+import PATH_TO_ROUTE from "@constants/bridge";
+import { Href } from "expo-router";
 import { RefObject } from "react";
 import WebView from "react-native-webview";
 
@@ -6,4 +8,27 @@ export const postMessage = (
   message: string,
 ) => {
   ref.current?.postMessage(message);
+};
+
+interface GetPathToRouteProps {
+  path: keyof typeof PATH_TO_ROUTE;
+  params?: { [key: string]: string | number }[];
+}
+
+export const getPathToRoute = ({ path, params }: GetPathToRouteProps): Href => {
+  let result = PATH_TO_ROUTE[path] as string;
+  if (!result) {
+    throw new Error(`Path not found for key: ${path}`);
+  }
+
+  // params 배열의 각 원소를 순회하며 [key]를 value로 치환
+  if (params && Array.isArray(params)) {
+    params.forEach((paramObj) => {
+      Object.entries(paramObj).forEach(([k, v]) => {
+        result = result.replace(new RegExp(`\\[${k}\\]`, "g"), String(v));
+      });
+    });
+  }
+
+  return result as Href;
 };


### PR DESCRIPTION
#27 
## 주요 변경 사항

안전 매뉴얼 스크린을 구현하였습니다. 
안전 매뉴얼 역시 전부 웹뷰로 구성하였습니다. 

<div align="center" display="flex">
<img width="50%" src="https://github.com/user-attachments/assets/afccd392-9eb2-4f28-aaf2-68022825fcd3"/>
<img width="50%" src="https://github.com/user-attachments/assets/5c68b2e9-6feb-443e-9a92-373a3e13fdda"/>
</div>


추가적으로, 라우팅 브리지를 하나로 통일함에 따라서 라우팅에 대한 책임을 WebviewWithInjected 컴포넌트에 두었습니다. 

WebviewWithInjected 컴포넌트 내에서 너무 많은 책임을 가지고 있어 이에 따라서 추후 책임분리가 필요할 것 같습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 안전 매뉴얼 웹뷰 및 상세 웹뷰 화면이 추가되었습니다.
  * 안전 매뉴얼 및 마이페이지 관련 네비게이션 레이아웃이 도입되었습니다.
  * 라우트 경로 매핑 및 동적 경로 생성 유틸리티가 추가되었습니다.

* **버그 수정**
  * 웹뷰에서 메시지 기반 라우팅 처리 및 뒤로가기 동작이 개선되었습니다.

* **리팩터링**
  * 여러 컴포넌트의 import 경로가 정리되고, 네이밍 및 경로 일관성이 향상되었습니다.
  * 불필요한 뷰 래퍼가 제거되어 레이아웃이 간결해졌습니다.

* **테스트**
  * 경로 생성 유틸리티에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->