### PR TITLE
[FEAT] 코스 상세 검색 스크린 구현

### DIFF
--- a/src/app/(tabs)/home/course/_layout.tsx
+++ b/src/app/(tabs)/home/course/_layout.tsx
@@ -1,0 +1,21 @@
+import { Stack } from "expo-router";
+
+const _layout = () => {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
+      <Stack.Screen
+        name="search"
+        options={{
+          animation: "fade",
+          animationDuration: 50,
+        }}
+      />
+    </Stack>
+  );
+};
+
+export default _layout;

--- a/src/app/(tabs)/home/course/search.tsx
+++ b/src/app/(tabs)/home/course/search.tsx
@@ -1,0 +1,7 @@
+import CourseSearchWebview from "@screens/course/CourseSearchWebview";
+
+const CourseSearchScreen = () => {
+  return <CourseSearchWebview />;
+};
+
+export default CourseSearchScreen;

--- a/src/components/common/entities/WebViewWithInjected/index.tsx
+++ b/src/components/common/entities/WebViewWithInjected/index.tsx
@@ -67,6 +67,15 @@ const WebViewWithInjected = forwardRef<WebView, WebViewWithInjectedProps>(
           status: "success",
         };
       }
+
+      if (reqMessage.name === "route-back" && reqMessage.method === "POST") {
+        router.back();
+
+        return {
+          name: "route-back",
+          status: "success",
+        };
+      }
     }, []);
 
     return (

--- a/src/components/feature/screens/course/CourseSearchWebview/index.tsx
+++ b/src/components/feature/screens/course/CourseSearchWebview/index.tsx
@@ -1,0 +1,18 @@
+import PATH_ROUTE from "@constants/pathRoute";
+import styled from "@emotion/native";
+import WebViewWithInjected from "@entities/WebViewWithInjected";
+
+const CourseSearchWebview = () => {
+  return (
+    <Container>
+      <WebViewWithInjected source={{ uri: PATH_ROUTE.WEBVIEW.COURSE_SEARCH }} />
+    </Container>
+  );
+};
+
+const Container = styled.SafeAreaView`
+  flex: 1;
+  background-color: white;
+`;
+
+export default CourseSearchWebview;

--- a/src/constants/bridge/index.ts
+++ b/src/constants/bridge/index.ts
@@ -7,6 +7,7 @@ const PATH_TO_ROUTE: PathToRoute = {
   "start-travel": "/travel",
   "mountain-course": "/(tabs)/map/course",
   "manual-detail": "/(tabs)/home/safeManual/[manual]",
+  "course-search": "/(tabs)/home/course/search",
 } as const;
 
 export default PATH_TO_ROUTE;

--- a/src/constants/pathRoute/index.ts
+++ b/src/constants/pathRoute/index.ts
@@ -21,6 +21,7 @@ const WEBVIEW = {
   SAFE_MANUAL_DETAIL: ({ manual }: { manual: string }) =>
     `${webviewBaseUri}/safe-manual/detail?manual=${manual}`,
   TRAVEL: `${webviewBaseUri}/travel`,
+  COURSE_SEARCH: `${webviewBaseUri}/course/search`,
 } as const;
 
 const PATH_ROUTE = {


### PR DESCRIPTION
- #15
## 주요 변경 사항

코스 상세 검색 스크린을 구현하였습니다. 

해당 스크린은 전부 웹뷰로 동작하여 웹뷰 컴포넌트를 사용하였습니다. 

<div align="center">
<img width="50%" src="https://github.com/user-attachments/assets/a8c6b9f2-4b09-4fab-a478-ac9e5c096be0"/>
</div>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 홈 탭 내 코스 검색 화면이 추가되었습니다.
  * 코스 검색 화면에서 웹뷰를 통해 코스 검색을 이용할 수 있습니다.
  * 웹뷰 내에서 뒤로 가기 요청 시 앱 내 네비게이션이 연동됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->