### PR TITLE
[FEAT] 마이페이지 홈 onMessage 로직 추가

### DIFF
--- a/src/components/feature/screens/mypage/MypageHomeWebview/index.tsx
+++ b/src/components/feature/screens/mypage/MypageHomeWebview/index.tsx
@@ -1,8 +1,37 @@
 import PATH_ROUTE from "@constants/pathRoute";
 import WebViewWithInjected from "@entities/WebViewWithInjected";
+import useLogout from "@hooks/feature/useLogout";
 
 const MypageHomeWebview = () => {
-  return <WebViewWithInjected source={{ uri: PATH_ROUTE.WEBVIEW.MYPAGE }} />;
+  const { logout } = useLogout();
+
+  return (
+    <WebViewWithInjected
+      source={{ uri: PATH_ROUTE.WEBVIEW.MYPAGE }}
+      onMessage={({ method, name }) => {
+        if (name === "logout" && method === "DELETE") {
+          try {
+            logout();
+            return {
+              name: "logout",
+              status: "success",
+            };
+          } catch (error) {
+            console.error("Logout failed:", error);
+            return {
+              name: "logout",
+              status: "error",
+            };
+          }
+        }
+
+        return {
+          name,
+          status: "error",
+        };
+      }}
+    />
+  );
 };
 
 export default MypageHomeWebview;

--- a/src/components/feature/screens/mypage/MypageHomeWebview/index.tsx
+++ b/src/components/feature/screens/mypage/MypageHomeWebview/index.tsx
@@ -11,11 +11,12 @@ const MypageHomeWebview = () => {
       onMessage={({ method, name }) => {
         if (name === "logout" && method === "DELETE") {
           try {
-            logout();
-            return {
-              name: "logout",
-              status: "success",
-            };
+            logout().then(() => {
+              return {
+                name: "logout",
+                status: "success",
+              };
+            });
           } catch (error) {
             console.error("Logout failed:", error);
             return {

--- a/src/components/feature/widget/AppleLoginButton/index.tsx
+++ b/src/components/feature/widget/AppleLoginButton/index.tsx
@@ -24,8 +24,6 @@ const AppleLoginButton = () => {
 
       const { identityToken, email, fullName } = credential;
 
-      console.log("애플 로그인 요청", credential);
-
       mutate(
         {
           identityToken,

--- a/src/constants/bridge/index.ts
+++ b/src/constants/bridge/index.ts
@@ -15,6 +15,7 @@ const PATH_TO_ROUTE: PathToRoute = {
   "check-terms": "/(tabs)/mypage/checkTerms",
   "customer-center": "/(tabs)/mypage/customerCenter/[tab]",
   "mountain-course": "/(tabs)/home/course/[mountainName]",
+  starter: "/starter",
 } as const;
 
 export default PATH_TO_ROUTE;

--- a/src/hooks/feature/useLogout/index.ts
+++ b/src/hooks/feature/useLogout/index.ts
@@ -1,0 +1,11 @@
+import { removeValueFromSecureStore } from "@utils/secureStore";
+
+const useLogout = () => {
+  const logout = async () => {
+    await removeValueFromSecureStore("accessToken");
+  };
+
+  return { logout };
+};
+
+export default useLogout;

--- a/src/hooks/feature/useLogout/index.ts
+++ b/src/hooks/feature/useLogout/index.ts
@@ -2,7 +2,12 @@ import { removeValueFromSecureStore } from "@utils/secureStore";
 
 const useLogout = () => {
   const logout = async () => {
-    await removeValueFromSecureStore("accessToken");
+    try {
+      await removeValueFromSecureStore("accessToken");
+    } catch (error) {
+      console.error("[useLogout] 로그아웃 중 에러 발생:", error);
+      throw error;
+    }
   };
 
   return { logout };

--- a/src/service/bridge/components/WebviewWithBridge/index.tsx
+++ b/src/service/bridge/components/WebviewWithBridge/index.tsx
@@ -30,6 +30,10 @@ const WebviewWithBridge = <ReqMessage, ResMessage>({
   const webViewRef = useRef<WebView>(null);
 
   useEffect(() => {
+    console.log(isReady);
+  }, [isReady]);
+
+  useEffect(() => {
     if (isReady) onReadyToMessage?.();
   }, [isReady, onReadyToMessage]);
 
@@ -50,31 +54,26 @@ const WebviewWithBridge = <ReqMessage, ResMessage>({
 
       // handshake
       // 웹으로부터 handshake sync 메시지 수신
-      if (!isReady && syn === 1 && ack === null) {
-        // Alert.alert("[app] handshake syn/ack received : " + _id);
-        // 웹에서 syn을 보냈을 때, syn/ack을 보내준다.
-        Bridge.createMessage(webViewRef, {
-          syn: 1,
-          ack: _id,
-        }).send<WebviewHandshake>(({ ack, flag: { syn } }) => {
-          // Alert.alert("[app] 끝끝!!!!!!!!!!!!!!!!!!!!!!!");
-          console.log(
-            `[${new Date().getHours()}:${new Date().getMinutes()}:${new Date().getSeconds()}]handshake end`,
-          );
-          if (!isReady && syn === 0 && ack !== null) {
-            setIsReady(true);
-            return;
-          }
-        });
-        return;
+      if (!isReady) {
+        if (!isReady && syn === 1 && ack === null) {
+          // 웹에서 syn을 보냈을 때, syn/ack을 보내준다.
+          Bridge.createMessage(webViewRef, {
+            syn: 1,
+            ack: _id,
+          }).send<WebviewHandshake>(({ ack, flag: { syn } }) => {
+            if (!isReady && syn === 0 && ack !== null) {
+              console.log(
+                `[${new Date().getHours()}:${new Date().getMinutes()}:${new Date().getSeconds()}]handshake end`,
+              );
+              setIsReady(true);
+              return;
+            }
+          });
+          return;
+        }
       }
 
-      if (!isReady) {
-        console.warn(
-          "[WebviewWithBridge] 웹부의 핸드쉐이크라 아직 완료되지 않았습니다. syn/ack 메시지를 확인해주세요.",
-        );
-        return;
-      }
+      if (!isReady) return;
 
       // body가 있는 일반 요청 메시지 처리
       if (!body) return;
@@ -94,7 +93,7 @@ const WebviewWithBridge = <ReqMessage, ResMessage>({
         }).send();
       }
     },
-    [onBridgeMessage, middleware],
+    [onBridgeMessage, middleware, isReady],
   );
 
   return <WebView ref={webViewRef} onMessage={handleMessage} {...props} />;

--- a/src/service/bridge/core/Message.ts
+++ b/src/service/bridge/core/Message.ts
@@ -2,7 +2,6 @@ import WebView from "react-native-webview";
 
 import { WebviewBridgeMessage } from "../types";
 import RWindow from "./RWindow";
-// import { Alert } from "react-native";
 
 class Message<BodyType = unknown> {
   private _id: string;
@@ -35,7 +34,6 @@ class Message<BodyType = unknown> {
     ref: React.RefObject<WebView<{}> | null>,
     message: WebviewBridgeMessage<ResMessage>,
   ) => {
-    // Alert.alert("[app] 앱에서 보냄 : ", JSON.stringify(message));
     ref.current?.postMessage(JSON.stringify(message));
   };
 

--- a/src/utils/bridge/index.ts
+++ b/src/utils/bridge/index.ts
@@ -18,7 +18,9 @@ interface GetPathToRouteProps {
 export const getPathToRoute = ({ path, params }: GetPathToRouteProps): Href => {
   let result = PATH_TO_ROUTE[path] as string;
   if (!result) {
-    throw new Error(`Path not found for key: ${path}`);
+    throw new Error(
+      `[getPathToRoute] 존재하지 않는 주소로 이동을 요청하였습니다 :  ${path}`,
+    );
   }
 
   // params 배열의 각 원소를 순회하며 [key]를 value로 치환


### PR DESCRIPTION
#31 

## 주요 변경 사항
마이페이지 홈 화면에서 브리지 요청에 대한 응답을 받을 수 있는 onMessage 로직을 추가하였습니다. 

현재 받을 수 있는 브리지 요청은 로그아웃이며, 요청을 받은 경우 토큰을 제거하고 성공 메시지를 보내주도록 하였습니다. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * WebView에서 로그아웃 요청 메시지를 수신하여 앱에서 로그아웃을 실행하는 기능이 추가되었습니다.
  * 로그아웃 처리를 위한 커스텀 훅이 도입되었습니다.
  * 새로운 경로 "/starter"가 라우트 매핑에 추가되었습니다.

* **버그 수정 및 개선**
  * Apple 로그인 시 불필요한 콘솔 로그가 제거되었습니다.
  * WebView와의 메시지 핸드셰이크 로직이 개선되어 안정성이 향상되었습니다.
  * 경로 매핑 오류 발생 시 더 상세하고 한글로 된 에러 메시지가 제공됩니다.

* **스타일 및 기타**
  * 불필요한 주석 및 디버깅 코드가 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->