### PR TITLE
[FIX] get method의 bridge 로직의 응답이 올바르게 보내지지 않던 버그 수정

### DIFF
--- a/src/components/common/entities/WebViewWithInjected/index.tsx
+++ b/src/components/common/entities/WebViewWithInjected/index.tsx
@@ -65,7 +65,6 @@ const WebViewWithInjected = ({
     const backAction = () => {
       if (canGoBack) {
         webViewRef.current?.goBack();
-        console.log(webViewRef.current);
         return true;
       }
       return false;
@@ -134,6 +133,11 @@ const WebViewWithInjected = ({
       };
 
       showToast(toastProps);
+
+      return {
+        name: "show-toast",
+        status: "success",
+      };
     }
   }, []);
 
@@ -184,6 +188,7 @@ const WebViewWithInjected = ({
         allowsLinkPreview={false}
         middleware={middleware}
         onReadyToMessage={onReadyToMessage}
+        strictMode={false}
         // 뒤로가기, 앞으로가기 기능
         onNavigationStateChange={(navState) => {
           setCanGoBack(navState.canGoBack);

--- a/src/service/bridge/components/WebviewWithBridge/index.tsx
+++ b/src/service/bridge/components/WebviewWithBridge/index.tsx
@@ -127,6 +127,24 @@ const WebviewWithBridge = <ReqMessage, ResMessage>({
               console.error("Error in onBridgeMessage:", error);
             });
           return;
+        } else {
+          // onBridgeMessage가 일반 값을 반환하는 경우
+          if (!resMessage) {
+            if (strictMode)
+              throw new Error(
+                "전달받은 브리지에 대한 응답이 없습니다. onBridgeMessage를 확인해주세요.\n" +
+                  `전달 받은 브리지 : ${JSON.stringify(body)}`,
+              );
+            else
+              console.warn(
+                "전달받은 브리지에 대한 응답이 없습니다. onBridgeMessage를 확인해주세요.\n" +
+                  `전달 받은 브리지 : ${JSON.stringify(body)}`,
+              );
+          }
+          Bridge.createMessage(webViewRef, {
+            ack: _id,
+            body: resMessage,
+          }).send();
         }
 
         if (!resMessage) {


### PR DESCRIPTION
closed #40

기존의 코드에서 onMessage로 전달받은 응답 데이터를 메시지로 보내주는 WebviewWithBridge 라이브러리의 로직에서, 
onMessage에 대한 콜백이 promise 가 아닌 경우에 대한 로직이 없어 응답이 올바르게 전송되지 않은 버그가 존재했습니다. 

이에 대한 로직을 추가하여 수정 완료하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 동기 방식의 메시지 응답 처리 시 누락된 응답 처리가 개선되어, 동기적으로 반환된 값도 정상적으로 인식 및 응답됩니다.
  * 불필요한 디버그 콘솔 로그가 제거되었습니다.

* **기타**
  * 내부 컴포넌트에 strictMode 옵션이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->