### PR TITLE
[FEAT] axios instance에서 response error가 발생한 경우, 이를 형식에 맞추어 포매팅할 수 있는 로직 추가

### DIFF
--- a/src/api/_instances/authenticatedApi/index.ts
+++ b/src/api/_instances/authenticatedApi/index.ts
@@ -49,14 +49,19 @@ authenticatedApi.interceptors.response.use(
       console.warn("[status:]", error.response?.status);
     }
 
-    const apiError: ErrorResponse = {
-      status: "error",
-      errorCode: error.response?.data.errorCode || "UNKNOWN_ERROR",
-      message:
-        error.response?.data?.message || "알 수 없는 오류가 발생했습니다.",
-    };
+    const err = Object.assign(
+      new Error(error.response?.data?.message || "알 수 없는 오류가 발생했습니다."),
+      {
+        name: "ApiError",
+        status: "error" as const,
+        errorCode: error.response?.data?.errorCode ?? "UNKNOWN_ERROR",
+        httpStatus: error.response?.status,
+        url: error.config?.url,
+        cause: error,
+      },
+    ) as Error & ErrorResponse & { httpStatus?: number; url?: string; cause?: unknown };
 
-    return Promise.reject(apiError);
+    return Promise.reject(err);
   },
 );
 

--- a/src/api/_instances/authenticatedApi/index.ts
+++ b/src/api/_instances/authenticatedApi/index.ts
@@ -1,5 +1,6 @@
+import { ErrorResponse } from "@model/api";
 import { getValueFromSecureStore } from "@utils/secureStore";
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 
 const { EXPO_PUBLIC_MODE } = process.env;
 
@@ -36,9 +37,10 @@ authenticatedApi.interceptors.response.use(
       console.log("[url:]", response.config.url);
       console.log("[data:]", response.data);
     }
+
     return response.data;
   },
-  (error) => {
+  (error: AxiosError<ErrorResponse>) => {
     if (EXPO_PUBLIC_MODE === "development") {
       console.warn("=============[authenticatedApi API error]=============");
       console.warn("[error :]", error);
@@ -46,7 +48,15 @@ authenticatedApi.interceptors.response.use(
       console.warn("[data:]", error.response?.data);
       console.warn("[status:]", error.response?.status);
     }
-    return Promise.reject(error);
+
+    const apiError: ErrorResponse = {
+      status: "error",
+      errorCode: error.response?.data.errorCode || "UNKNOWN_ERROR",
+      message:
+        error.response?.data?.message || "알 수 없는 오류가 발생했습니다.",
+    };
+
+    return Promise.reject(apiError);
   },
 );
 

--- a/src/api/_instances/publicApi/index.ts
+++ b/src/api/_instances/publicApi/index.ts
@@ -64,15 +64,20 @@ publicApi.interceptors.response.use(
       console.error("[data:]", error.response?.data);
       console.error("[status:]", error.response?.status);
     }
+    
+    const err = Object.assign(
+      new Error(error.response?.data?.message || "알 수 없는 오류가 발생했습니다."),
+      {
+        name: "ApiError",
+        status: "error" as const,
+        errorCode: error.response?.data?.errorCode ?? "UNKNOWN_ERROR",
+        httpStatus: error.response?.status,
+        url: error.config?.url,
+        cause: error,
+      },
+    ) as Error & ErrorResponse & { httpStatus?: number; url?: string; cause?: unknown };
 
-    const apiError: ErrorResponse = {
-      status: "error",
-      errorCode: error.response?.data.errorCode || "UNKNOWN_ERROR",
-      message:
-        error.response?.data?.message || "알 수 없는 오류가 발생했습니다.",
-    };
-
-    return Promise.reject(apiError);
+    return Promise.reject(err);
   },
 );
 

--- a/src/api/_instances/publicApi/index.ts
+++ b/src/api/_instances/publicApi/index.ts
@@ -1,3 +1,4 @@
+import { ErrorResponse } from "@model/api";
 import axios from "axios";
 
 const { EXPO_PUBLIC_MODE } = process.env;
@@ -63,7 +64,15 @@ publicApi.interceptors.response.use(
       console.error("[data:]", error.response?.data);
       console.error("[status:]", error.response?.status);
     }
-    return Promise.reject(error);
+
+    const apiError: ErrorResponse = {
+      status: "error",
+      errorCode: error.response?.data.errorCode || "UNKNOWN_ERROR",
+      message:
+        error.response?.data?.message || "알 수 없는 오류가 발생했습니다.",
+    };
+
+    return Promise.reject(apiError);
   },
 );
 

--- a/src/model/api/index.ts
+++ b/src/model/api/index.ts
@@ -1,0 +1,5 @@
+export interface ErrorResponse {
+  status: "error";
+  errorCode: string;
+  message: string;
+}


### PR DESCRIPTION
#49

axios instance에서 reponse error가 발생한 경우, 이를 형식에 맞추어 포매팅할 수 있는 로직을 추가하였습니다.
앞으로 api 관련 에러 핸들링을 하는 위치에서는 에러 타입을 추론할 수 있게 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 모든 API 응답의 오류를 표준화하는 오류 스키마를 도입해 상태, 오류코드, 메시지를 일관되게 제공합니다.
  - 예기치 않은 오류 발생 시 기본 한국어 메시지(“알 수 없는 오류가 발생했습니다.”)를 표시합니다.
- Bug Fixes
  - 다양한 API 오류 형식으로 인한 화면/알림 처리 실패를 완화해 사용자 경험을 안정화했습니다.
  - 개발 모드에서의 오류 로깅은 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->